### PR TITLE
Don't break out of the custom extension callback loop - continue instead

### DIFF
--- a/ssl/ssltest.c
+++ b/ssl/ssltest.c
@@ -576,8 +576,7 @@ static int custom_ext_0_cli_second_cb(SSL *s, unsigned short ext_type,
 				      unsigned short inlen, int *al,
 				      void *arg)
 	{
-	custom_ext_error = 1; /* Shouldn't be called */
-	return 0;
+	return 1;
 	}
 
 static int custom_ext_1_cli_first_cb(SSL *s, unsigned short ext_type,
@@ -596,8 +595,7 @@ static int custom_ext_1_cli_second_cb(SSL *s, unsigned short ext_type,
 				      unsigned short inlen, int *al,
 				      void *arg)
 	{
-	custom_ext_error = 1; /* Shouldn't be called */
-	return 0;
+	return 1;
 	}
 
 static int custom_ext_2_cli_first_cb(SSL *s, unsigned short ext_type,
@@ -654,8 +652,7 @@ static int custom_ext_0_srv_first_cb(SSL *s, unsigned short ext_type,
 				     unsigned short inlen, int *al,
 				     void *arg)
 	{
-	custom_ext_error = 1;
-	return 0; /* Shouldn't be called */
+	return 1;
 	}
 
 /* 'generate' callbacks are always called, even if the 'receive' callback isn't called */

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1708,14 +1708,14 @@ unsigned char *ssl_add_serverhello_tlsext(SSL *s, unsigned char *p, unsigned cha
 
 		/* NULL callback or -1 omits extension */
 		if (!record->fn2)
-			break;
+			continue;
 		cb_retval = record->fn2(s, record->ext_type,
 								&out, &outlen, al,
 								record->arg);
 		if (cb_retval == 0)
 			return NULL; /* error */
 		if (cb_retval == -1)
-			break; /* skip this extension */
+			continue; /* skip this extension */
 		if (limit < ret + 4 + outlen)
 			return NULL;
 		s2n(record->ext_type, ret);


### PR DESCRIPTION
The contract for custom extension callbacks has changed - all custom extension callbacks are triggered
